### PR TITLE
fix: build cli entry point instead of library exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "dev": "bun run src/cli/index.ts",
-    "build": "bun build src/index.ts --outdir dist --target bun",
+    "build": "bun build src/cli/index.ts --outdir dist --target bun",
     "test": "bun test",
     "lint": "oxlint . && bun run typecheck && bun run knip",
     "typecheck": "bun x tsc --noEmit",


### PR DESCRIPTION
## Problem

The build script was building `src/index.ts` (library exports) but the `bin` entry in package.json points to `dist/index.js` expecting a CLI entry point.

This caused the published npm package to have **no working CLI** - running `repo-lint --help` produced no output because the bundled file only exported library functions without any main execution.

## Solution

Changed the build entry point from `src/index.ts` to `src/cli/index.ts`:

```diff
-"build": "bun build src/index.ts --outdir dist --target bun"
+"build": "bun build src/cli/index.ts --outdir dist --target bun"
```

## Verification

- ✅ All 143 tests pass
- ✅ `bun run build` produces working CLI
- ✅ `bun run dist/index.js --help` shows help output
- ✅ `bun run dist/index.js check` runs successfully