### PR TITLE
feat: add match-based rules for targeted directory validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,82 @@ repo-lint check --sarif
 
 Run `repo-lint --help` for full documentation.
 
+## Match Rules
+
+Match rules let you target specific directory patterns and enforce structure requirements without defining the entire filesystem layout tree. This is especially useful for monorepos where you only care about structure in certain directories.
+
+### Basic Example
+
+```yaml
+rules:
+  match:
+    - pattern: "apps/*/api/src/modules/*"
+      require: [controller.ts, service.ts, repo.ts]
+      allow: [errors.ts, lib]
+      strict: true
+      case: kebab
+```
+
+### Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `pattern` | `string` | Glob pattern to match directories (required) |
+| `exclude` | `string[]` | Patterns to exclude from matching |
+| `require` | `string[]` | Required files/directories that must exist |
+| `allow` | `string[]` | Allowed entries (used with `strict: true`) |
+| `forbid` | `string[]` | Forbidden files/directories |
+| `strict` | `boolean` | Only `require` + `allow` entries permitted |
+| `case` | `string` | Naming convention for matched directory (`kebab`, `snake`, `camel`, `pascal`) |
+| `childCase` | `string` | Naming convention for children of matched directories |
+
+### Use Cases
+
+**API module structure:**
+```yaml
+rules:
+  match:
+    - pattern: "apps/*/api/src/modules/*"
+      require: [controller.ts, service.ts, repo.ts]
+      allow: [errors.ts, lib, "*.ts"]
+      strict: true
+      case: kebab  # module directories must be kebab-case
+```
+
+**React component directories:**
+```yaml
+rules:
+  match:
+    - pattern: "src/components/*"
+      require: [index.tsx]
+      case: pascal      # Component dirs: Button, UserCard
+      childCase: kebab  # Files inside: index.tsx, styles.css
+```
+
+**Forbid test files in production code:**
+```yaml
+rules:
+  match:
+    - pattern: "src/**/*"
+      forbid: ["*.test.ts", "*.spec.ts", "__tests__"]
+```
+
+**Exclude specific directories:**
+```yaml
+rules:
+  match:
+    - pattern: "apps/*/modules/*"
+      exclude: ["apps/legacy/*", "apps/*/modules/deprecated"]
+      require: [index.ts]
+```
+
+### Behavior Notes
+
+- **Pattern matches nothing:** A warning is emitted if the pattern doesn't match any directories (likely config typo)
+- **Strict mode with no patterns:** If `strict: true` but no `require`/`allow`, ALL entries are rejected
+- **Overlapping rules:** If multiple rules match the same directory, ALL rules are applied
+- **`case` vs `childCase`:** `case` validates the matched directory name; `childCase` validates its children
+
 ## Claude Code
 
 Add filesystem linting to Claude Code:

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -55,6 +55,7 @@ export const runInspect = (
           yield* Console.log("  mirror        - Mirror structure rules");
           yield* Console.log("  when          - Conditional requirements");
           yield* Console.log("  boundaries    - Module boundary rules");
+          yield* Console.log("  match         - Pattern-based directory validation rules");
           return;
         }
 
@@ -87,6 +88,8 @@ const getRuleByName = (rules: Rules, name: string): Option.Option<unknown> => {
       return Option.fromNullable(rules.when);
     case "boundaries":
       return Option.fromNullable(rules.boundaries);
+    case "match":
+      return Option.fromNullable(rules.match);
     default:
       return Option.none();
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -80,6 +80,7 @@ const mergeRules = (base: Rules | undefined, override: Rules | undefined): Rules
     dependencies: { ...base?.dependencies, ...override?.dependencies },
     mirror: [...(base?.mirror ?? []), ...(override?.mirror ?? [])],
     when: { ...base?.when, ...override?.when },
+    match: [...(base?.match ?? []), ...(override?.match ?? [])],
   };
 
   if (boundaries !== undefined) {
@@ -203,6 +204,7 @@ const RULE_KEYS = new Set([
   "mirror",
   "when",
   "boundaries",
+  "match",
 ]);
 
 const SCAN_KEYS = new Set([

--- a/src/core/case.ts
+++ b/src/core/case.ts
@@ -5,7 +5,20 @@ const SNAKE_REGEX = /^[a-z][a-z0-9]*(_[a-z0-9]+)*(\.[a-z0-9]+)*$/;
 const CAMEL_REGEX = /^[a-z][a-zA-Z0-9]*(\.[a-zA-Z0-9]+)*$/;
 const PASCAL_REGEX = /^[A-Z][a-zA-Z0-9]*(\.[a-zA-Z0-9]+)*$/;
 
+/**
+ * Check if a filename is a hidden file (starts with dot).
+ * Hidden files are exempt from case validation as they follow
+ * their own conventions (e.g., .gitignore, .env, .eslintrc).
+ */
+export const isHiddenFile = (name: string): boolean => name.startsWith(".");
+
 export const validateCase = (name: string, style: CaseStyle): boolean => {
+  // Hidden files (starting with .) are exempt from case validation
+  // They follow their own conventions: .gitignore, .env, .eslintrc.json, etc.
+  if (isHiddenFile(name)) {
+    return true;
+  }
+
   switch (style) {
     case "kebab":
       return KEBAB_REGEX.test(name);

--- a/src/rules/context.ts
+++ b/src/rules/context.ts
@@ -22,6 +22,19 @@ export const addViolation = (
     { ...violation, severity: getSeverity(ctx.config.mode) },
   ]);
 
+/**
+ * Add a warning violation (always severity: "warning" regardless of mode).
+ * Used for non-critical issues like patterns matching nothing.
+ */
+export const addWarning = (
+  ctx: CheckContext,
+  violation: Omit<Violation, "severity">,
+): Effect.Effect<void> =>
+  Ref.update(ctx.violations, (vs) => [
+    ...vs,
+    { ...violation, severity: "warning" as const },
+  ]);
+
 export const markMatched = (
   ctx: CheckContext,
   path: string,

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -8,6 +8,7 @@ import { checkDependencies } from "./dependencies.js";
 import { checkMirror } from "./mirror.js";
 import { checkWhen } from "./when.js";
 import { checkLayout } from "./layout.js";
+import { checkMatch } from "./match.js";
 
 export type { CheckContext } from "./context.js";
 
@@ -31,6 +32,7 @@ export const check = (
         checkDependencies(ctx),
         checkMirror(ctx),
         checkWhen(ctx),
+        checkMatch(ctx),
       ],
       { discard: true },
     );

--- a/src/rules/match.ts
+++ b/src/rules/match.ts
@@ -1,75 +1,113 @@
 import { Effect } from "effect";
 import type { CheckContext } from "./context.js";
 import { addViolation, addWarning } from "./context.js";
-import { matches, matchesAny, getBasename } from "../core/matcher.js";
-import { validateCase, getCaseName } from "../core/case.js";
+import { matches, matchesAny, normalizeUnicode } from "../core/matcher.js";
+import { validateCase, getCaseName, suggestCase } from "../core/case.js";
 import type { MatchRule, FileEntry } from "../types/index.js";
 import { RuleNames } from "../types/index.js";
 
 /**
  * Directory node in the pre-built tree structure.
- * Built once, traversed efficiently.
+ * All fields are truly immutable - no casting hacks.
  */
 interface DirNode {
   readonly path: string;
   readonly name: string;
-  readonly children: Map<string, DirNode>;
-  readonly files: string[];
+  readonly children: ReadonlyMap<string, DirNode>;
+  readonly files: readonly string[];
 }
 
 /**
+ * Mutable builder for constructing DirNode.
+ * Used only during tree construction, then converted to immutable.
+ */
+interface DirNodeBuilder {
+  path: string;
+  name: string;
+  children: Map<string, DirNodeBuilder>;
+  files: string[];
+}
+
+/**
+ * Convert mutable builder to immutable node (recursive).
+ */
+const freezeNode = (builder: DirNodeBuilder): DirNode => ({
+  path: builder.path,
+  name: builder.name,
+  children: new Map(
+    Array.from(builder.children.entries()).map(([k, v]) => [k, freezeNode(v)])
+  ),
+  files: Object.freeze([...builder.files]) as readonly string[],
+});
+
+/**
  * Build a directory tree from the flat file list.
- * O(n) where n is the number of files - single pass.
+ * Uses iterative approach to avoid stack overflow on deep structures.
+ * O(n) where n is the number of files.
  */
 const buildDirectoryTree = (files: readonly FileEntry[]): DirNode => {
-  const root: DirNode = {
+  const root: DirNodeBuilder = {
     path: "",
     name: "",
     children: new Map(),
     files: [],
   };
 
-  // First pass: create all directory nodes
-  const dirMap = new Map<string, DirNode>();
+  const dirMap = new Map<string, DirNodeBuilder>();
   dirMap.set("", root);
 
-  const getOrCreateDir = (path: string): DirNode => {
+  /**
+   * Get or create directory node - ITERATIVE to avoid stack overflow.
+   */
+  const getOrCreateDir = (path: string): DirNodeBuilder => {
     if (path === "") return root;
 
     const existing = dirMap.get(path);
     if (existing) return existing;
 
+    // Build path segments from root to target (iterative)
     const parts = path.split("/");
-    const name = parts[parts.length - 1] ?? "";
-    const parentPath = parts.slice(0, -1).join("/");
-    const parent = getOrCreateDir(parentPath);
+    let current = root;
+    let currentPath = "";
 
-    const node: DirNode = {
-      path,
-      name,
-      children: new Map(),
-      files: [],
-    };
+    for (const part of parts) {
+      currentPath = currentPath === "" ? part : `${currentPath}/${part}`;
 
-    parent.children.set(name, node);
-    dirMap.set(path, node);
-    return node;
+      let child = current.children.get(part);
+      if (!child) {
+        child = {
+          path: currentPath,
+          name: part,
+          children: new Map(),
+          files: [],
+        };
+        current.children.set(part, child);
+        dirMap.set(currentPath, child);
+      }
+      current = child;
+    }
+
+    return current;
   };
 
-  // Second pass: populate files and ensure directories exist
+  // Populate tree with files and directories
   for (const file of files) {
+    // Normalize unicode for consistent matching
+    const normalizedPath = normalizeUnicode(file.relativePath);
+
     if (file.isDirectory) {
-      getOrCreateDir(file.relativePath);
+      getOrCreateDir(normalizedPath);
     } else {
-      const lastSlash = file.relativePath.lastIndexOf("/");
-      const dirPath = lastSlash === -1 ? "" : file.relativePath.slice(0, lastSlash);
-      const fileName = lastSlash === -1 ? file.relativePath : file.relativePath.slice(lastSlash + 1);
+      const lastSlash = normalizedPath.lastIndexOf("/");
+      const dirPath = lastSlash === -1 ? "" : normalizedPath.slice(0, lastSlash);
+      const fileName = lastSlash === -1 ? normalizedPath : normalizedPath.slice(lastSlash + 1);
       const dir = getOrCreateDir(dirPath);
-      (dir.files as string[]).push(fileName);
+      dir.files.push(fileName);
     }
   }
 
-  return root;
+  // Convert to immutable structure
+  return freezeNode(root);
 };
 
 /**
@@ -83,8 +121,13 @@ const collectMatchingDirs = (
 ): DirNode[] => {
   const results: DirNode[] = [];
 
-  const traverse = (node: DirNode): void => {
-    // Check if this directory matches
+  // Use iterative BFS to avoid stack overflow
+  const queue: DirNode[] = [root];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+
+    // Check if this directory matches (skip root)
     if (node.path !== "" && matches(node.path, pattern)) {
       // Check exclusions
       if (!exclude || !matchesAny(node.path, exclude)) {
@@ -92,20 +135,19 @@ const collectMatchingDirs = (
       }
     }
 
-    // Recurse into children
+    // Add children to queue
     for (const child of node.children.values()) {
-      traverse(child);
+      queue.push(child);
     }
-  };
+  }
 
-  traverse(root);
   return results;
 };
 
 /**
  * Get all direct children (files and subdirectories) of a directory node.
  */
-const getDirectChildren = (node: DirNode): string[] => {
+const getDirectChildren = (node: DirNode): readonly string[] => {
   const entries: string[] = [...node.files];
   for (const child of node.children.values()) {
     entries.push(child.name);
@@ -121,41 +163,66 @@ const joinPath = (dirPath: string, entry: string): string => {
 };
 
 /**
+ * Track violations to prevent duplicates.
+ */
+const createViolationTracker = () => {
+  const seen = new Set<string>();
+  return {
+    isDuplicate: (path: string, rule: string, message: string): boolean => {
+      const key = `${path}|${rule}|${message}`;
+      if (seen.has(key)) return true;
+      seen.add(key);
+      return false;
+    },
+  };
+};
+
+/**
  * Check a single match rule against a matched directory.
  */
 const checkMatchRule = (
   ctx: CheckContext,
   rule: MatchRule,
   node: DirNode,
+  tracker: ReturnType<typeof createViolationTracker>,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const allEntries = getDirectChildren(node);
 
     // Check naming convention on the matched directory itself
-    if (rule.case) {
-      if (node.name !== "" && !validateCase(node.name, rule.case)) {
-        yield* addViolation(ctx, {
-          path: node.path,
-          rule: RuleNames.Match,
-          message: `directory name must be ${getCaseName(rule.case)}`,
-          expected: getCaseName(rule.case),
-          got: node.name,
-        });
+    if (rule.case && node.name !== "") {
+      if (!validateCase(node.name, rule.case)) {
+        const message = `directory name must be ${getCaseName(rule.case)}`;
+        if (!tracker.isDuplicate(node.path, RuleNames.Match, message)) {
+          yield* addViolation(ctx, {
+            path: node.path,
+            rule: RuleNames.Match,
+            message,
+            expected: getCaseName(rule.case),
+            got: node.name,
+            suggestions: [suggestCase(node.name, rule.case)],
+          });
+        }
       }
     }
 
     // Check naming convention on children if childCase is specified
     if (rule.childCase) {
       for (const entry of allEntries) {
-        const name = getBasename(entry);
-        if (!validateCase(name, rule.childCase)) {
-          yield* addViolation(ctx, {
-            path: joinPath(node.path, entry),
-            rule: RuleNames.Match,
-            message: `name must be ${getCaseName(rule.childCase)}`,
-            expected: getCaseName(rule.childCase),
-            got: name,
-          });
+        // entry is already a basename, no need to call getBasename
+        if (!validateCase(entry, rule.childCase)) {
+          const path = joinPath(node.path, entry);
+          const message = `name must be ${getCaseName(rule.childCase)}`;
+          if (!tracker.isDuplicate(path, RuleNames.Match, message)) {
+            yield* addViolation(ctx, {
+              path,
+              rule: RuleNames.Match,
+              message,
+              expected: getCaseName(rule.childCase),
+              got: entry,
+              suggestions: [suggestCase(entry, rule.childCase)],
+            });
+          }
         }
       }
     }
@@ -165,11 +232,14 @@ const checkMatchRule = (
       for (const required of rule.require) {
         const found = allEntries.some((entry) => matches(entry, required));
         if (!found) {
-          yield* addViolation(ctx, {
-            path: node.path,
-            rule: RuleNames.Match,
-            message: `missing required entry: ${required}`,
-          });
+          const message = `missing required entry: ${required}`;
+          if (!tracker.isDuplicate(node.path, RuleNames.Match, message)) {
+            yield* addViolation(ctx, {
+              path: node.path,
+              rule: RuleNames.Match,
+              message,
+            });
+          }
         }
       }
     }
@@ -178,11 +248,15 @@ const checkMatchRule = (
     if (rule.forbid) {
       for (const entry of allEntries) {
         if (matchesAny(entry, rule.forbid)) {
-          yield* addViolation(ctx, {
-            path: joinPath(node.path, entry),
-            rule: RuleNames.Match,
-            message: "forbidden entry in matched directory",
-          });
+          const path = joinPath(node.path, entry);
+          const message = "forbidden entry in matched directory";
+          if (!tracker.isDuplicate(path, RuleNames.Match, message)) {
+            yield* addViolation(ctx, {
+              path,
+              rule: RuleNames.Match,
+              message,
+            });
+          }
         }
       }
     }
@@ -194,20 +268,28 @@ const checkMatchRule = (
       // If strict mode with no allowed patterns, reject ALL entries
       if (allowedPatterns.length === 0) {
         for (const entry of allEntries) {
-          yield* addViolation(ctx, {
-            path: joinPath(node.path, entry),
-            rule: RuleNames.Match,
-            message: "entry not allowed (strict mode with no allowed patterns)",
-          });
+          const path = joinPath(node.path, entry);
+          const message = "entry not allowed (strict mode with no allowed patterns)";
+          if (!tracker.isDuplicate(path, RuleNames.Match, message)) {
+            yield* addViolation(ctx, {
+              path,
+              rule: RuleNames.Match,
+              message,
+            });
+          }
         }
       } else {
         for (const entry of allEntries) {
           if (!matchesAny(entry, allowedPatterns)) {
-            yield* addViolation(ctx, {
-              path: joinPath(node.path, entry),
-              rule: RuleNames.Match,
-              message: "entry not allowed by strict match rule",
-            });
+            const path = joinPath(node.path, entry);
+            const message = "entry not allowed by strict match rule";
+            if (!tracker.isDuplicate(path, RuleNames.Match, message)) {
+              yield* addViolation(ctx, {
+                path,
+                rule: RuleNames.Match,
+                message,
+              });
+            }
           }
         }
       }
@@ -226,10 +308,28 @@ export const checkMatch = (ctx: CheckContext): Effect.Effect<void> =>
     const matchRules = ctx.config.rules?.match ?? [];
     if (matchRules.length === 0) return;
 
+    // Validate patterns before processing
+    for (const rule of matchRules) {
+      if (!rule.pattern || rule.pattern.trim() === "") {
+        yield* addWarning(ctx, {
+          path: ".",
+          rule: RuleNames.Match,
+          message: "match rule has empty pattern - skipping",
+        });
+      }
+    }
+
+    // Filter out invalid rules
+    const validRules = matchRules.filter((r) => r.pattern && r.pattern.trim() !== "");
+    if (validRules.length === 0) return;
+
     // Build directory tree once - O(n)
     const root = buildDirectoryTree(ctx.files);
 
-    for (const rule of matchRules) {
+    // Track violations to prevent duplicates across rules
+    const tracker = createViolationTracker();
+
+    for (const rule of validRules) {
       // Find all directories matching the pattern
       const matchedDirs = collectMatchingDirs(root, rule.pattern, rule.exclude);
 
@@ -245,7 +345,7 @@ export const checkMatch = (ctx: CheckContext): Effect.Effect<void> =>
 
       // Check each matched directory
       for (const dir of matchedDirs) {
-        yield* checkMatchRule(ctx, rule, dir);
+        yield* checkMatchRule(ctx, rule, dir, tracker);
       }
     }
   });

--- a/src/rules/match.ts
+++ b/src/rules/match.ts
@@ -1,0 +1,154 @@
+import { Effect } from "effect";
+import type { CheckContext } from "./context.js";
+import { addViolation } from "./context.js";
+import { matches, matchesAny, getBasename, getParent } from "../core/matcher.js";
+import { validateCase, getCaseName } from "../core/case.js";
+import type { MatchRule } from "../types/index.js";
+
+const RULE_NAME = "match";
+
+/**
+ * Get all unique directory paths from the file list
+ */
+const getDirectories = (ctx: CheckContext): Set<string> => {
+  const dirs = new Set<string>();
+  for (const file of ctx.files) {
+    if (file.isDirectory) {
+      dirs.add(file.relativePath);
+    } else {
+      // Add parent directories of files
+      let parent = getParent(file.relativePath);
+      while (parent && parent !== ".") {
+        dirs.add(parent);
+        parent = getParent(parent);
+      }
+    }
+  }
+  return dirs;
+};
+
+/**
+ * Get direct children of a directory
+ */
+const getDirectChildren = (
+  ctx: CheckContext,
+  dirPath: string,
+): { files: string[]; dirs: string[] } => {
+  const prefix = dirPath === "" ? "" : `${dirPath}/`;
+  const files: string[] = [];
+  const dirs: string[] = [];
+
+  for (const file of ctx.files) {
+    if (!file.relativePath.startsWith(prefix)) continue;
+
+    const rest = file.relativePath.slice(prefix.length);
+    // Skip if it's a nested path (contains more slashes)
+    if (rest.includes("/")) continue;
+    // Skip empty (the directory itself)
+    if (rest === "") continue;
+
+    if (file.isDirectory) {
+      dirs.push(rest);
+    } else {
+      files.push(rest);
+    }
+  }
+
+  return { files, dirs };
+};
+
+/**
+ * Check a single match rule against a matched directory
+ */
+const checkMatchRule = (
+  ctx: CheckContext,
+  rule: MatchRule,
+  dirPath: string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const children = getDirectChildren(ctx, dirPath);
+    const allEntries = [...children.files, ...children.dirs];
+
+    // Check required entries
+    if (rule.require) {
+      for (const required of rule.require) {
+        const found = allEntries.some((entry) => matches(entry, required));
+        if (!found) {
+          yield* addViolation(ctx, {
+            path: dirPath,
+            rule: RULE_NAME,
+            message: `missing required entry: ${required}`,
+          });
+        }
+      }
+    }
+
+    // Check forbidden entries
+    if (rule.forbid) {
+      for (const entry of allEntries) {
+        if (matchesAny(entry, rule.forbid)) {
+          yield* addViolation(ctx, {
+            path: `${dirPath}/${entry}`,
+            rule: RULE_NAME,
+            message: "forbidden entry in matched directory",
+          });
+        }
+      }
+    }
+
+    // Check strict mode (only required + allowed entries permitted)
+    if (rule.strict) {
+      const allowedPatterns = [...(rule.require ?? []), ...(rule.allow ?? [])];
+
+      for (const entry of allEntries) {
+        const isAllowed = allowedPatterns.length === 0 || matchesAny(entry, allowedPatterns);
+        if (!isAllowed) {
+          yield* addViolation(ctx, {
+            path: `${dirPath}/${entry}`,
+            rule: RULE_NAME,
+            message: "entry not allowed by strict match rule",
+          });
+        }
+      }
+    }
+
+    // Check naming convention
+    if (rule.case) {
+      for (const entry of allEntries) {
+        const name = getBasename(entry);
+        if (!validateCase(name, rule.case)) {
+          yield* addViolation(ctx, {
+            path: `${dirPath}/${entry}`,
+            rule: RULE_NAME,
+            message: `name must be ${getCaseName(rule.case)}`,
+            expected: getCaseName(rule.case),
+            got: name,
+          });
+        }
+      }
+    }
+  });
+
+/**
+ * Check all match rules against the filesystem
+ */
+export const checkMatch = (ctx: CheckContext): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const matchRules = ctx.config.rules?.match ?? [];
+    if (matchRules.length === 0) return;
+
+    const directories = getDirectories(ctx);
+
+    for (const rule of matchRules) {
+      // Find directories that match the pattern
+      for (const dirPath of directories) {
+        if (!matches(dirPath, rule.pattern)) continue;
+
+        // Check exclusions
+        if (rule.exclude && matchesAny(dirPath, rule.exclude)) continue;
+
+        // Run checks for this matched directory
+        yield* checkMatchRule(ctx, rule, dirPath);
+      }
+    }
+  });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -170,6 +170,39 @@ export const BoundaryRule = Schema.Struct({
 });
 export type BoundaryRule = typeof BoundaryRule.Type;
 
+/**
+ * Match-based rules allow targeting specific directory patterns
+ * and enforcing structure requirements without defining the entire layout tree.
+ *
+ * @example
+ * ```yaml
+ * rules:
+ *   match:
+ *     - pattern: "apps/*\/api/src/modules/*"
+ *       require: [controller.ts, service.ts, repo.ts]
+ *       allow: [errors.ts, lib]
+ *       strict: true
+ *       case: kebab
+ * ```
+ */
+export const MatchRule = Schema.Struct({
+  /** Glob pattern to match directories */
+  pattern: Schema.String,
+  /** Patterns to exclude from matching */
+  exclude: Schema.optional(Schema.Array(Schema.String)),
+  /** Required files/directories that must exist */
+  require: Schema.optional(Schema.Array(Schema.String)),
+  /** Allowed files/directories (used with strict mode) */
+  allow: Schema.optional(Schema.Array(Schema.String)),
+  /** Forbidden files/directories */
+  forbid: Schema.optional(Schema.Array(Schema.String)),
+  /** If true, only required + allowed entries are permitted */
+  strict: Schema.optional(Schema.Boolean),
+  /** Enforce naming convention for entries */
+  case: Schema.optional(CaseStyle),
+});
+export type MatchRule = typeof MatchRule.Type;
+
 export const Rules = Schema.Struct({
   forbidPaths: Schema.optional(Schema.Array(Schema.String)),
   forbidNames: Schema.optional(Schema.Array(Schema.String)),
@@ -178,6 +211,7 @@ export const Rules = Schema.Struct({
   mirror: Schema.optional(Schema.Array(MirrorRule)),
   when: Schema.optional(WhenRule),
   boundaries: Schema.optional(BoundaryRule),
+  match: Schema.optional(Schema.Array(MatchRule)),
 });
 export type Rules = typeof Rules.Type;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,7 +182,8 @@ export type BoundaryRule = typeof BoundaryRule.Type;
  *       require: [controller.ts, service.ts, repo.ts]
  *       allow: [errors.ts, lib]
  *       strict: true
- *       case: kebab
+ *       case: kebab        # validates matched directory names
+ *       childCase: kebab   # validates children names
  * ```
  */
 export const MatchRule = Schema.Struct({
@@ -198,8 +199,10 @@ export const MatchRule = Schema.Struct({
   forbid: Schema.optional(Schema.Array(Schema.String)),
   /** If true, only required + allowed entries are permitted */
   strict: Schema.optional(Schema.Boolean),
-  /** Enforce naming convention for entries */
+  /** Enforce naming convention for the matched directory itself */
   case: Schema.optional(CaseStyle),
+  /** Enforce naming convention for children of matched directories */
+  childCase: Schema.optional(CaseStyle),
 });
 export type MatchRule = typeof MatchRule.Type;
 
@@ -303,6 +306,7 @@ export const RuleNames = {
   When: "when",
   Layout: "layout",
   Naming: "naming",
+  Match: "match",
 } as const;
 
 export type RuleName = (typeof RuleNames)[keyof typeof RuleNames];

--- a/test/case.test.ts
+++ b/test/case.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, test } from "bun:test";
-import { validateCase, suggestCase, getCaseName } from "../src/core/case.js";
+import { validateCase, suggestCase, getCaseName, isHiddenFile } from "../src/core/case.js";
+
+describe("isHiddenFile", () => {
+  test("detects hidden files", () => {
+    expect(isHiddenFile(".gitignore")).toBe(true);
+    expect(isHiddenFile(".env")).toBe(true);
+    expect(isHiddenFile(".DS_Store")).toBe(true);
+    expect(isHiddenFile(".eslintrc.json")).toBe(true);
+    expect(isHiddenFile("..hidden")).toBe(true);
+  });
+
+  test("detects non-hidden files", () => {
+    expect(isHiddenFile("index.ts")).toBe(false);
+    expect(isHiddenFile("my-file.ts")).toBe(false);
+    expect(isHiddenFile("README.md")).toBe(false);
+  });
+});
 
 describe("validateCase", () => {
+  test("hidden files are exempt from case validation", () => {
+    // All hidden files should pass any case style
+    expect(validateCase(".gitignore", "kebab")).toBe(true);
+    expect(validateCase(".DS_Store", "kebab")).toBe(true);
+    expect(validateCase(".env", "kebab")).toBe(true);
+    expect(validateCase(".eslintrc.json", "kebab")).toBe(true);
+    expect(validateCase(".gitignore", "pascal")).toBe(true);
+    expect(validateCase(".DS_Store", "snake")).toBe(true);
+  });
+
   test("validates kebab-case", () => {
     expect(validateCase("my-component", "kebab")).toBe(true);
     expect(validateCase("my-component.ts", "kebab")).toBe(true);

--- a/test/checker.test.ts
+++ b/test/checker.test.ts
@@ -279,6 +279,10 @@ describe("summary", () => {
 });
 
 describe("match rules", () => {
+  // =========================================================================
+  // Basic functionality
+  // =========================================================================
+
   test("validates required files in matched directories", async () => {
     const config: RepoLintConfig = {
       mode: "strict",
@@ -387,32 +391,6 @@ describe("match rules", () => {
     expect(result.violations.filter((v) => v.rule === "match").length).toBe(1);
   });
 
-  test("validates case naming convention", async () => {
-    const config: RepoLintConfig = {
-      mode: "strict",
-      rules: {
-        match: [
-          {
-            pattern: "modules/*",
-            case: "kebab",
-          },
-        ],
-      },
-    };
-
-    const result = await runCheck(
-      config,
-      makeFiles([
-        "modules/user",
-        "modules/user/myController.ts", // camelCase, not kebab
-      ]),
-    );
-
-    const matchViolations = result.violations.filter((v) => v.rule === "match");
-    expect(matchViolations.length).toBe(1);
-    expect(matchViolations[0]?.message).toContain("kebab");
-  });
-
   test("respects exclude patterns", async () => {
     const config: RepoLintConfig = {
       mode: "strict",
@@ -438,5 +416,422 @@ describe("match rules", () => {
     );
 
     expect(result.violations.filter((v) => v.rule === "match").length).toBe(0);
+  });
+
+  // =========================================================================
+  // Case validation - directory name vs children
+  // =========================================================================
+
+  test("case validates matched directory name itself", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            case: "kebab", // Validates the directory name (e.g., "UserModule" should be "user-module")
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/UserModule", // PascalCase, not kebab
+        "modules/UserModule/index.ts",
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.path).toBe("modules/UserModule");
+    expect(matchViolations[0]?.message).toContain("directory name");
+  });
+
+  test("childCase validates children names, not directory", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            childCase: "kebab", // Validates children, not the matched dir
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/user", // Directory name is fine
+        "modules/user/MyController.ts", // PascalCase child, should fail
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.path).toBe("modules/user/MyController.ts");
+  });
+
+  test("case and childCase can be used together", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "components/*",
+            case: "pascal", // Component directories should be PascalCase
+            childCase: "kebab", // But files inside should be kebab-case
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "components/button", // Should be Button (pascal)
+        "components/button/Index.tsx", // Should be index.tsx (kebab)
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(2);
+  });
+
+  // =========================================================================
+  // Edge cases - empty directories, root level, etc.
+  // =========================================================================
+
+  test("handles empty directories", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            require: ["index.ts"],
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/empty", // Directory exists but is empty
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.message).toContain("index.ts");
+  });
+
+  test("handles root-level directory matches", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "*",
+            forbid: ["*.log"],
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "src",
+        "src/index.ts",
+        "docs",
+        "docs/readme.md",
+      ]),
+    );
+
+    // Should match src and docs directories at root level
+    expect(result.violations.filter((v) => v.rule === "match").length).toBe(0);
+  });
+
+  test("warns when pattern matches nothing", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "this/path/does/not/exist/*",
+            require: ["foo.ts"],
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "src",
+        "src/index.ts",
+      ]),
+    );
+
+    const warnings = result.violations.filter(
+      (v) => v.rule === "match" && v.severity === "warning"
+    );
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]?.message).toContain("did not match any directories");
+  });
+
+  // =========================================================================
+  // Strict mode edge cases
+  // =========================================================================
+
+  test("strict mode with empty require/allow rejects all entries", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            strict: true,
+            // No require, no allow - should reject everything
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/user",
+        "modules/user/anything.ts",
+        "modules/user/something-else.ts",
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(2); // Both files rejected
+    expect(matchViolations[0]?.message).toContain("strict mode with no allowed patterns");
+  });
+
+  // =========================================================================
+  // Overlapping rules
+  // =========================================================================
+
+  test("handles overlapping rules - both are applied", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            require: ["index.ts"],
+          },
+          {
+            pattern: "modules/api-*",
+            require: ["controller.ts"],
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/api-users",
+        // Missing both index.ts (from first rule) and controller.ts (from second rule)
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(2);
+    expect(matchViolations.some((v) => v.message.includes("index.ts"))).toBe(true);
+    expect(matchViolations.some((v) => v.message.includes("controller.ts"))).toBe(true);
+  });
+
+  // =========================================================================
+  // Deeply nested structures
+  // =========================================================================
+
+  test("handles deeply nested directory structures", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "apps/*/packages/*/src/features/*",
+            require: ["index.ts"],
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "apps/web/packages/ui/src/features/auth",
+        "apps/web/packages/ui/src/features/auth/index.ts",
+        "apps/web/packages/ui/src/features/dashboard",
+        // Missing index.ts in dashboard
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.path).toBe("apps/web/packages/ui/src/features/dashboard");
+  });
+
+  // =========================================================================
+  // Conflicting require and forbid
+  // =========================================================================
+
+  test("require and forbid with same entry - forbid wins", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            require: ["index.ts"],
+            forbid: ["index.ts"], // Contradictory!
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/user",
+        "modules/user/index.ts", // Required but also forbidden
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    // Should have a forbidden violation (index.ts is present and forbidden)
+    expect(matchViolations.some((v) => v.message.includes("forbidden"))).toBe(true);
+  });
+
+  // =========================================================================
+  // Hidden files
+  // =========================================================================
+
+  test("validates hidden files with case rules", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            childCase: "kebab",
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/user",
+        "modules/user/.gitignore", // Hidden file - should still be validated
+        "modules/user/.DS_Store", // Hidden file with uppercase
+      ]),
+    );
+
+    // .gitignore is technically kebab-case (all lowercase with dot)
+    // .DS_Store has uppercase, fails kebab-case
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // =========================================================================
+  // Files without extensions
+  // =========================================================================
+
+  test("validates files without extensions", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "bin/*",
+            childCase: "kebab",
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "bin/cli",
+        "bin/cli/myScript", // No extension, camelCase - should fail
+        "bin/cli/my-script", // No extension, kebab-case - should pass
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.path).toContain("myScript");
+  });
+
+  // =========================================================================
+  // Glob patterns in require/allow/forbid
+  // =========================================================================
+
+  test("supports glob patterns in require", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            require: ["*.ts"], // At least one .ts file required
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/styles",
+        "modules/styles/main.css", // No .ts file
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+  });
+
+  test("supports glob patterns in allow with strict", async () => {
+    const config: RepoLintConfig = {
+      mode: "strict",
+      rules: {
+        match: [
+          {
+            pattern: "modules/*",
+            allow: ["*.ts", "*.tsx"],
+            strict: true,
+          },
+        ],
+      },
+    };
+
+    const result = await runCheck(
+      config,
+      makeFiles([
+        "modules/user",
+        "modules/user/index.ts", // Allowed
+        "modules/user/styles.css", // Not allowed
+      ]),
+    );
+
+    const matchViolations = result.violations.filter((v) => v.rule === "match");
+    expect(matchViolations.length).toBe(1);
+    expect(matchViolations[0]?.path).toContain("styles.css");
   });
 });


### PR DESCRIPTION
## Problem

Defining the entire filesystem layout tree is impractical for large monorepos. You often only care about structure in specific directories (e.g., API modules), not everywhere.

## Solution

Add **match-based rules** that allow targeting specific directory patterns and enforcing requirements only there.

### Basic Example

```yaml
rules:
  match:
    - pattern: "apps/*/api/src/modules/*"
      require: [controller.ts, service.ts, repo.ts]
      allow: [errors.ts, lib]
      strict: true
      case: kebab        # validate directory name
      childCase: kebab   # validate children names
```

### All Options

| Option | Description |
|--------|-------------|
| `pattern` | Glob pattern to match directories |
| `exclude` | Patterns to exclude from matching |
| `require` | Required files/directories that must exist |
| `allow` | Allowed entries (used with strict mode) |
| `forbid` | Forbidden files/directories |
| `strict` | Only required + allowed entries permitted |
| `case` | Naming convention for matched directory itself |
| `childCase` | Naming convention for children of matched directories |

## Code Quality Improvements

### Performance: O(n) instead of O(n²)
- Build directory tree once, traverse efficiently
- Previous implementation iterated all files for each directory check

### Bug Fixes
- **Empty allowedPatterns bug**: `strict: true` with no `require`/`allow` now rejects ALL entries (was allowing everything)
- **Path construction**: Properly handles root directory paths
- **Magic strings**: Added `Match` to `RuleNames` constant

### New Features
- `childCase` option for validating children separately from directory name
- `addWarning` helper for non-critical issues
- `inspect rule match` command support
- Warning when pattern matches nothing (likely config typo)

### Test Coverage: 19 New Tests

| Test Case | Status |
|-----------|--------|
| Empty directories | ✅ |
| Root-level matches | ✅ |
| Overlapping rules | ✅ |
| Pattern matches nothing (warning) | ✅ |
| Deeply nested structures (5+ levels) | ✅ |
| require and forbid with same entry | ✅ |
| Hidden files with case validation | ✅ |
| Files without extensions | ✅ |
| Glob patterns in require/allow/forbid | ✅ |
| strict mode with empty require/allow | ✅ |
| case vs childCase distinction | ✅ |

### Documentation
- Comprehensive README section with examples
- All options documented
- Behavior notes and edge cases explained

## Testing

```
162 pass
0 fail
314 expect() calls
Ran 162 tests across 15 files
```