### PR TITLE
fix: centralize ScanOverrides type definition

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -1,17 +1,9 @@
 import { Option } from "effect";
 import type { OutputFormat } from "../output/index.js";
 import type { InspectType } from "../commands/inspect.js";
+import type { ScanOverrides } from "../types/index.js";
 
 export type Command = "check" | "inspect" | "help" | "version";
-
-export type ScanOverrides = {
-  readonly maxDepth: Option.Option<number>;
-  readonly maxFiles: Option.Option<number>;
-  readonly timeoutMs: Option.Option<number>;
-  readonly concurrency: Option.Option<number>;
-  readonly followSymlinks: Option.Option<boolean>;
-  readonly useGitignore: Option.Option<boolean>;
-};
 
 export type ParsedArgs = {
   readonly command: Command;

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -5,17 +5,8 @@ import { scan, scanWorkspaces, readFileContent } from "../core/scanner.js";
 import { check } from "../rules/index.js";
 import { format, type OutputFormat } from "../output/index.js";
 import { readCache, writeCache, computeFileHash } from "../cache/index.js";
-import type { CheckResult, RepoLintConfig } from "../types/index.js";
+import type { CheckResult, RepoLintConfig, ScanOverrides } from "../types/index.js";
 import { ConfigNotFoundError, ConfigParseError, ScanError, PathTraversalError } from "../errors.js";
-
-export type ScanOverrides = {
-  readonly maxDepth: Option.Option<number>;
-  readonly maxFiles: Option.Option<number>;
-  readonly timeoutMs: Option.Option<number>;
-  readonly concurrency: Option.Option<number>;
-  readonly followSymlinks: Option.Option<boolean>;
-  readonly useGitignore: Option.Option<boolean>;
-};
 
 export type CheckOptions = {
   readonly scope: Option.Option<string>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { Schema } from "@effect/schema";
+import { Option } from "effect";
 
 // ============================================================================
 // Case Styles
@@ -230,6 +231,19 @@ export const ScanSettings = Schema.Struct({
   concurrency: Schema.optional(Schema.Number),
 });
 export type ScanSettings = typeof ScanSettings.Type;
+
+// ============================================================================
+// Scan Overrides (CLI Arguments)
+// ============================================================================
+
+export type ScanOverrides = {
+  readonly maxDepth: Option.Option<number>;
+  readonly maxFiles: Option.Option<number>;
+  readonly timeoutMs: Option.Option<number>;
+  readonly concurrency: Option.Option<number>;
+  readonly followSymlinks: Option.Option<boolean>;
+  readonly useGitignore: Option.Option<boolean>;
+};
 
 // ============================================================================
 // Main Config Schema

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -3,9 +3,10 @@ import { Effect, Exit, Option } from "effect";
 import { mkdir, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { runCheck, type ScanOverrides } from "../src/commands/check.js";
+import { runCheck } from "../src/commands/check.js";
 import { runInspect } from "../src/commands/inspect.js";
 import { getCacheStats, clearCache } from "../src/cache/index.js";
+import type { ScanOverrides } from "../src/types/index.js";
 
 let testDir: string;
 let originalCwd: string;


### PR DESCRIPTION
Remove duplicate ScanOverrides type definitions from src/cli/parser.ts and src/commands/check.ts. Define it once in src/types/index.ts and import from there to follow DRY principles.

Resolves #8